### PR TITLE
Fix triggerable publish workflow input handling

### DIFF
--- a/.github/workflows/common_publish-from-tarball.yml
+++ b/.github/workflows/common_publish-from-tarball.yml
@@ -18,18 +18,17 @@ on:
         description: "Container registry to login and push to (<container-registry>/<registry-namespace>/<image-name>:<image-tag>)"
         required: true
         type: string
-      registry-user:
-        description: "Container registry login username"
-        required: true
-        type: string
-      registry-password:
-        description: "container registry login password"
-        required: true
-        type: string
       output-tag:
         description: "What to re-tag the image as and where to push to? E.g. ghcr.io/my-username/my-repo:latest"
         required: true
         type: string
+    secrets:
+      registry-user:
+        description: "Container registry login username"
+        required: true
+      registry-password:
+        description: "container registry login password"
+        required: true
 jobs:
   publish-docker-package:
     runs-on: ubuntu-latest
@@ -51,8 +50,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.container-registry }}
-          username: ${{ inputs.registry-user }}
-          password: ${{ inputs.registry-password }}
+          username: ${{ secrets.registry-user }}
+          password: ${{ secrets.registry-password }}
       - name: Tag Docker image for pushing
         run: |
           docker tag ${{ inputs.input-tag }} ${{ inputs.output-tag }}

--- a/.github/workflows/workflow_merge-to-main.yml
+++ b/.github/workflows/workflow_merge-to-main.yml
@@ -20,6 +20,7 @@ jobs:
       tar-path-in-artifact: ${{ needs.test-build-and-package.outputs.docker-tar-path }}
       input-tag: ghcr.io/${{ github.repository_owner }}/htmx-go-portfolio:${{ github.sha }}
       container-registry: ghcr.io
+      output-tag: ghcr.io/${{ github.repository_owner }}/htmx-go-portfolio:${{ github.sha }}
+    secrets:
       registry-user: ${{ github.actor }}
       registry-password: ${{ github.token }}
-      output-tag: ghcr.io/${{ github.repository_owner }}/htmx-go-portfolio:${{ github.sha }}


### PR DESCRIPTION
Token seems to be null, and there is secrets key anyways to use.

It might still be `null` after this PR, but let's keep golfing.