### PR TITLE
Set default credentials when context is available

### DIFF
--- a/.github/workflows/common_publish-from-tarball.yml
+++ b/.github/workflows/common_publish-from-tarball.yml
@@ -23,21 +23,21 @@ on:
         description: "What to re-tag the image as? E.g. my-username/my-repo:latest"
         required: true
         type: string
+    secrets:
       registry-user:
-        description: "Container registry login username. Leave empty if publishing to GHCR."
-        default: ${{ github.actor }}
+        description: "Container registry login username. Default: github.actor."
         required: false
-        type: string
       registry-password:
-        description: "Container registry login password. Leave empty if publishing to GHCR."
-        default: ${{ github.token }}
+        description: "Container registry login password. Default: github.token."
         required: false
-        type: string
 jobs:
   publish-docker-package:
     runs-on: ubuntu-latest
     env:
       EXTRACT_DIR: ./tmp
+      # Use GH credentials if not given
+      DOCKER_USER: ${{ secrets.registry-user != "" && secrets.registry-user || github.actor }}
+      DOCKER_PASS: ${{ secrets.registry-password != "" && secrets.registry-password || github.token }}
     steps:
       - name: Download Docker image artifact
         uses: actions/download-artifact@v4
@@ -54,8 +54,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.container-registry }}
-          username: ${{ secrets.registry-user }}
-          password: ${{ secrets.registry-password }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_PASS }}
       - name: Tag Docker image for pushing
         run: |
           docker tag ${{ inputs.input-tag }} ${{ inputs.container-registry }}/${{ inputs.output-tag }}


### PR DESCRIPTION
Could redact with `::add-mask::(...)` but this should already handle it (secrets are redacted already, and github.actor is visible anyways and obvious in code)