### PR TITLE
Allow triggered workflow to write packages

### DIFF
--- a/.github/workflows/workflow_merge-to-main.yml
+++ b/.github/workflows/workflow_merge-to-main.yml
@@ -14,6 +14,8 @@ jobs:
       image-tag: ${{ github.sha }}
   publish-to-ghcr:
     needs: [test-build-and-package]
+    permissions:
+      packages: write
     uses: ./.github/workflows/common_publish-from-tarball.yml
     with:
       docker-artifact-name: ${{ needs.test-build-and-package.outputs.docker-artifact-name }}


### PR DESCRIPTION
> The GITHUB_TOKEN permissions passed from the caller workflow can
> be only downgraded (not elevated) by the called workflow.

Fixes:

```
The nested job 'publish-docker-package' is requesting 'packages: write',
but is only allowed 'packages: read'.
```